### PR TITLE
add kaggle and sagemaker studio-lab badge in notebooks

### DIFF
--- a/docs/source/notebooks/developer_guide.ipynb
+++ b/docs/source/notebooks/developer_guide.ipynb
@@ -65,6 +65,8 @@
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/alphanome-ai/sec-parser/blob/main/docs/source/notebooks/developer_guide.ipynb)\n",
     "[![My Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/alphanome-ai/sec-parser/main?filepath=docs/source/notebooks/developer_guide.ipynb)\n",
+    "[![Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://www.kaggle.com/kernels/welcome?src=https://github.com/alphanome-ai/sec-parser/blob/main/docs/source/notebooks/developer_guide.ipynb)\n",
+    "[![Open in SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/https://github.com/alphanome-ai/sec-parser/blob/main/docs/source/notebooks/developer_guide.ipynb)\n",
     "\n",
     "Let's dive in!"
    ]

--- a/docs/source/notebooks/user_guide.ipynb
+++ b/docs/source/notebooks/user_guide.ipynb
@@ -65,6 +65,8 @@
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/alphanome-ai/sec-parser/blob/main/docs/source/notebooks/user_guide.ipynb)\n",
     "[![My Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/alphanome-ai/sec-parser/main?filepath=docs/source/notebooks/user_guide.ipynb)\n",
+    "[![Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://www.kaggle.com/kernels/welcome?src=https://github.com/alphanome-ai/sec-parser/blob/main/docs/source/notebooks/user_guide.ipynb)\n",
+    "[![Open in SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/https://github.com/alphanome-ai/sec-parser/blob/main/docs/source/notebooks/user_guide.ipynb)\n",
     "\n",
     "Let's get started!"
    ]


### PR DESCRIPTION
## What does this PR do?

As mentioned in #27 added the badges for `Kaggle` and `Amazon Sagemaker Studio Lab`

The change comprises of just this
```md
[![Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://www.kaggle.com/kernels/welcome?src=https://github.com/alphanome-ai/sec-parser/blob/main/docs/source/notebooks/user_guide.ipynb)
[![Open in SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/https://github.com/alphanome-ai/sec-parser/blob/main/docs/source/notebooks/user_guide.ipynb)
```

Which adds the badges like this-

[![Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://www.kaggle.com/kernels/welcome?src=https://github.com/alphanome-ai/sec-parser/blob/main/docs/source/notebooks/user_guide.ipynb)
[![Open in SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/https://github.com/alphanome-ai/sec-parser/blob/main/docs/source/notebooks/user_guide.ipynb)

<img width="907" alt="Screenshot 2023-10-16 at 4 56 28 PM" src="https://github.com/alphanome-ai/sec-parser/assets/82315953/01043c8d-1923-4aea-baea-645869540e6a">
