### PR TITLE
test: add unit tests for image_check and xbrl_tag_check

### DIFF
--- a/tests/unit/processing_steps/individual_semantic_element_extractor/single_element_checks/test_image_check.py
+++ b/tests/unit/processing_steps/individual_semantic_element_extractor/single_element_checks/test_image_check.py
@@ -1,0 +1,63 @@
+from unittest.mock import Mock
+import bs4
+import pytest
+
+from sec_parser.semantic_elements.abstract_semantic_element import AbstractSemanticElement
+from sec_parser.processing_steps.individual_semantic_element_extractor.single_element_checks.image_check import ImageCheck
+
+
+def test_contains_single_element_with_img_tag():
+    # Arrange
+    element = AbstractSemanticElement(Mock())
+    element.html_tag.name = "img"
+    check = ImageCheck()
+
+    # Act
+    actual = check.contains_single_element(element)
+
+    # Assert
+    assert actual is True
+    
+
+def test_contains_single_element_with_multiple_img_tags():
+    # Arrange
+    element = AbstractSemanticElement(Mock())
+    element.html_tag.name = "div"
+    element.html_tag.count_tags.side_effect = lambda tag_name: 2 if tag_name == 'img' else 0
+    check = ImageCheck()
+
+    # Act
+    actual = check.contains_single_element(element)
+
+    # Assert
+    assert actual is False
+
+
+def test_contains_single_element_with_text_and_img_tag():
+    # Arrange
+    element = AbstractSemanticElement(Mock())
+    element.html_tag.name = "div"
+    element.html_tag.count_tags.side_effect = lambda tag_name: 1 if tag_name == 'img' else 0
+    element.html_tag.text = "Some text"
+    check = ImageCheck()
+
+    # Act
+    actual = check.contains_single_element(element)
+
+    # Assert
+    assert actual is False
+
+
+def test_contains_single_element_with_other_tags():
+    # Arrange
+    element = AbstractSemanticElement(Mock())
+    element.html_tag.name = "div"
+    element.html_tag.count_tags.side_effect = lambda tag_name: 0 if tag_name == 'img' else 2
+    element.html_tag.text = ""
+    check = ImageCheck()
+
+    # Act
+    actual = check.contains_single_element(element)
+
+    # Assert
+    assert actual is None

--- a/tests/unit/processing_steps/individual_semantic_element_extractor/single_element_checks/test_xbrl_tag_check.py
+++ b/tests/unit/processing_steps/individual_semantic_element_extractor/single_element_checks/test_xbrl_tag_check.py
@@ -1,0 +1,19 @@
+from unittest.mock import Mock
+import bs4
+import pytest
+
+from sec_parser.semantic_elements.abstract_semantic_element import AbstractSemanticElement
+from sec_parser.processing_steps.individual_semantic_element_extractor.single_element_checks.xbrl_tag_check import XbrlTagCheck
+
+
+def test_contains_single_element():
+    # Arrange
+    element = AbstractSemanticElement(Mock())
+    element.html_tag.name = "ix"
+    check = XbrlTagCheck()
+
+    # Act
+    actual = check.contains_single_element(element)
+
+    # Assert
+    assert actual is False #TODO(@INF800): Verify if `True` or `False` is expected.

--- a/tests/unit/processing_steps/individual_semantic_element_extractor/single_element_checks/test_xbrl_tag_check.py
+++ b/tests/unit/processing_steps/individual_semantic_element_extractor/single_element_checks/test_xbrl_tag_check.py
@@ -16,4 +16,4 @@ def test_contains_single_element():
     actual = check.contains_single_element(element)
 
     # Assert
-    assert actual is False #TODO(@INF800): Verify if `True` or `False` is expected.
+    assert actual is False


### PR DESCRIPTION
Related to #34 

---

<s>May need to change `test_xbrl_tag_check`'s assertion statement based on this discussion: https://github.com/orgs/alphanome-ai/discussions/38.

I think this was supposed to be `True`.
https://github.com/alphanome-ai/sec-parser/blob/b1b9213b1e2b01da6c1acf820d462e05270a75b3/sec_parser/processing_steps/individual_semantic_element_extractor/single_element_checks/xbrl_tag_check.py#L22</s>

**Update:** Ready for review based on the answer from discussion https://github.com/orgs/alphanome-ai/discussions/38.