### PR TITLE
Fix title element merger

### DIFF
--- a/sec_parser/processing_engine/core.py
+++ b/sec_parser/processing_engine/core.py
@@ -43,6 +43,7 @@ from sec_parser.processing_steps.table_of_contents_classifier import (
 from sec_parser.processing_steps.text_classifier import TextClassifier
 from sec_parser.processing_steps.text_element_merger import TextElementMerger
 from sec_parser.processing_steps.title_classifier import TitleClassifier
+from sec_parser.processing_steps.title_element_merger import TitleElementMerger
 from sec_parser.processing_steps.top_section_manager import (
     TopSectionManagerFor10K,
     TopSectionManagerFor10Q,
@@ -199,6 +200,7 @@ class Edgar10QParser(AbstractSemanticElementParser):
                 types_to_process={TextElement, HighlightedTextElement},
             ),
             TitleClassifier(types_to_process={HighlightedTextElement}),
+            TitleElementMerger(),
             TextElementMerger(),
         ]
 
@@ -244,6 +246,7 @@ class Edgar10KParser(AbstractSemanticElementParser):
                 types_to_process={TextElement, HighlightedTextElement},
             ),
             TitleClassifier(types_to_process={HighlightedTextElement}),
+            TitleElementMerger(),
             TextElementMerger(),
         ]
 

--- a/sec_parser/processing_steps/__init__.py
+++ b/sec_parser/processing_steps/__init__.py
@@ -46,6 +46,7 @@ from sec_parser.processing_steps.table_of_contents_classifier import (
 from sec_parser.processing_steps.text_classifier import TextClassifier
 from sec_parser.processing_steps.text_element_merger import TextElementMerger
 from sec_parser.processing_steps.title_classifier import TitleClassifier
+from sec_parser.processing_steps.title_element_merger import TitleElementMerger
 from sec_parser.processing_steps.top_section_manager import (
     TopSectionManagerFor10K,
     TopSectionManagerFor10Q,
@@ -69,6 +70,7 @@ __all__ = [
     "TextClassifier",
     "TextElementMerger",
     "TitleClassifier",
+    "TitleElementMerger",
     "TopSectionManagerFor10K",
     "TopSectionManagerFor10Q",
     "TopSectionTitleCheck",

--- a/sec_parser/processing_steps/title_element_merger.py
+++ b/sec_parser/processing_steps/title_element_merger.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import TYPE_CHECKING, cast
+
+from sec_parser.processing_engine.html_tag import HtmlTag
+from sec_parser.processing_steps.abstract_classes.abstract_element_batch_processing_step import (
+    AbstractElementBatchProcessingStep,
+)
+from sec_parser.semantic_elements.abstract_semantic_element import (
+    AbstractSemanticElement,
+)
+from sec_parser.semantic_elements.title_element import TitleElement
+
+if TYPE_CHECKING:  # pragma: no cover
+    from sec_parser.processing_steps.abstract_classes.processing_context import (
+        ElementProcessingContext,
+    )
+
+
+class TitleElementMerger(AbstractElementBatchProcessingStep):
+    """
+    TitleElementMerger is a processing step that merges adjacent TitleElement instances
+    that are on the same line. This addresses issues where section titles are split
+    across multiple HTML elements (e.g., "PART I. FINANCI" and "AL INFORMATION").
+
+    The merger identifies TitleElements with the same level that are:
+    1. Adjacent in the element list
+    2. On the same line (have the same parent HTML element)
+    3. Have similar styling (optional heuristic)
+
+    Example:
+    -------
+        Before: TitleElement("PART I. FINANCI") + TitleElement("AL INFORMATION")
+        After:  TitleElement("PART I. FINANCIAL INFORMATION")
+
+    """
+
+    def _process_elements(
+        self,
+        elements: list[AbstractSemanticElement],
+        _: ElementProcessingContext,
+    ) -> list[AbstractSemanticElement]:
+        result: deque[AbstractSemanticElement | None] = deque(elements)
+        batch_indices: list[list[int]] = [[]]
+
+        # Group adjacent TitleElements with the same level
+        for i, element in enumerate(elements):
+            if isinstance(element, TitleElement):
+                # Check if this element can be merged with the previous batch
+                if (batch_indices[-1] and
+                    self._can_merge_with_batch(element, [elements[j] for j in batch_indices[-1]])):
+                    batch_indices[-1].append(i)
+                else:
+                    # Start a new batch
+                    if batch_indices[-1]:  # Only add new batch if previous one is not empty
+                        batch_indices.append([])
+                    batch_indices[-1].append(i)
+            elif batch_indices[-1]:
+                # Non-TitleElement breaks the batch
+                batch_indices.append([])
+
+        # Merge each batch
+        for indices in batch_indices:
+            if len(indices) <= 1:
+                continue
+            result[indices[0]] = self._merge(
+                cast(
+                    list[AbstractSemanticElement],
+                    [result[i] for i in indices if result[i]],
+                ),
+            )
+            for i in indices[1:]:
+                result[i] = None
+
+        return [element for element in result if element is not None]
+
+    def _can_merge_with_batch(
+        self,
+        element: TitleElement,
+        batch_elements: list[AbstractSemanticElement],
+    ) -> bool:
+        """Check if a TitleElement can be merged with a batch of elements."""
+        if not batch_elements:
+            return True
+
+        # All elements in batch must be TitleElements
+        if not all(isinstance(e, TitleElement) for e in batch_elements):
+            return False
+
+        # Check if all elements have the same level
+        batch_level = batch_elements[0].level
+        if element.level != batch_level:
+            return False
+
+        # Check if elements are on the same line (same parent)
+        batch_parent = batch_elements[0].html_tag.parent
+        element_parent = element.html_tag.parent
+
+        if batch_parent is None or element_parent is None:
+            return False
+
+        # Elements are on the same line if they have the same parent
+        if batch_parent._bs4 != element_parent._bs4:  # noqa: SLF001
+            return False
+
+        # Additional check: Don't merge sibling div elements that are separate titles
+        # This prevents merging of separate title divs that happen to be siblings
+        batch_tag = batch_elements[0].html_tag
+        element_tag = element.html_tag
+
+        # Only apply this check to div elements (not span elements)
+        # Span elements are typically used for split titles that should be merged
+        # Div elements are typically used for separate titles that should not be merged
+        if (batch_tag.name == "div" and element_tag.name == "div" and
+            batch_parent._bs4 == element_parent._bs4):  # noqa: SLF001
+
+            # For div elements that are siblings, check if they represent separate titles
+            batch_text = batch_elements[0].text.strip()
+            element_text = element.text.strip()
+
+            # If both texts appear to be complete, independent titles, don't merge them
+            # This prevents cases like "Components of Results of Operations" + "Revenue"
+            # from being merged into "Components of Results of OperationsRevenue"
+            if batch_text and element_text:
+                # Check if both texts appear to be complete, independent titles
+                # For single words, we need them to be reasonably long to be considered complete titles
+                # For multi-word phrases, they are likely complete titles
+                min_single_word_length = 5
+                batch_is_substantial = len(batch_text.split()) > 1 or len(batch_text) > min_single_word_length
+                element_is_substantial = len(element_text.split()) > 1 or len(element_text) > min_single_word_length
+
+                # Additional check: if both texts are substantial AND they don't appear to be
+                # part of a split title (i.e., they don't end/start with incomplete words),
+                # then they are likely separate titles that should not be merged
+                if (batch_is_substantial and element_is_substantial and
+                    batch_text and batch_text[-1].isalpha() and
+                    element_text and element_text[0].isalpha()):
+                    return False
+
+        return True
+
+    @classmethod
+    def _merge(
+        cls,
+        elements: list[AbstractSemanticElement],
+    ) -> AbstractSemanticElement:
+        """Merge multiple TitleElements into a single TitleElement."""
+        if not elements:
+            msg = "Cannot merge empty list of elements"
+            raise ValueError(msg)
+
+        if len(elements) == 1:
+            return elements[0]
+
+        # All elements should be TitleElements
+        title_elements = [cast(TitleElement, e) for e in elements]
+
+        # Create a new HTML tag that wraps all the merged elements
+        new_tag = HtmlTag.wrap_tags_in_new_parent(
+            "sec-parser-merged-title",
+            [e.html_tag for e in title_elements],
+        )
+
+        # Use the processing log from the first element
+        merged_processing_log = title_elements[0].processing_log.copy()
+
+        # Add a log entry about the merging
+        merged_processing_log.add_item(
+            message=f"Merged {len(title_elements)} TitleElements: {[e.text for e in title_elements]}",
+            log_origin=cls.__name__,
+        )
+
+        # Create the merged TitleElement with the same level as the first element
+        return TitleElement(
+            new_tag,
+            processing_log=merged_processing_log,
+            level=title_elements[0].level,
+            log_origin=cls.__name__,
+        )
+

--- a/sec_parser/processing_steps/title_element_merger.py
+++ b/sec_parser/processing_steps/title_element_merger.py
@@ -24,16 +24,14 @@ class TitleElementMerger(AbstractElementBatchProcessingStep):
     that are on the same line. This addresses issues where section titles are split
     across multiple HTML elements (e.g., "PART I. FINANCI" and "AL INFORMATION").
 
-    The merger identifies TitleElements with the same level that are:
-    1. Adjacent in the element list
-    2. On the same line (have the same parent HTML element)
-    3. Have similar styling (optional heuristic)
-
-    Example:
-    -------
-        Before: TitleElement("PART I. FINANCI") + TitleElement("AL INFORMATION")
-        After:  TitleElement("PART I. FINANCIAL INFORMATION")
-
+    Intended to fix weird formatting artifacts, such as:
+        <div style="line-height:120%;padding-top:12px;font-size:10pt;">
+            <font style="font-family:inherit;font-size:10pt;font-weight:bold;">PART I. FINANCI</font>
+        </div>
+        <div style="line-height:120%;padding-top:12px;font-size:10pt;">
+            <font style="font-family:inherit;font-size:10pt;font-weight:bold;">AL INFORMATION</font>
+        </div>
+    Notice, how titles are split into multiple divs, even though they form a single title.
     """
 
     def _process_elements(
@@ -44,23 +42,18 @@ class TitleElementMerger(AbstractElementBatchProcessingStep):
         result: deque[AbstractSemanticElement | None] = deque(elements)
         batch_indices: list[list[int]] = [[]]
 
-        # Group adjacent TitleElements with the same level
         for i, element in enumerate(elements):
             if isinstance(element, TitleElement):
-                # Check if this element can be merged with the previous batch
                 if (batch_indices[-1] and
                     self._can_merge_with_batch(element, [elements[j] for j in batch_indices[-1]])):
                     batch_indices[-1].append(i)
                 else:
-                    # Start a new batch
-                    if batch_indices[-1]:  # Only add new batch if previous one is not empty
+                    if batch_indices[-1]:
                         batch_indices.append([])
                     batch_indices[-1].append(i)
             elif batch_indices[-1]:
-                # Non-TitleElement breaks the batch
                 batch_indices.append([])
 
-        # Merge each batch
         for indices in batch_indices:
             if len(indices) <= 1:
                 continue
@@ -84,61 +77,43 @@ class TitleElementMerger(AbstractElementBatchProcessingStep):
         if not batch_elements:
             return True
 
-        # All elements in batch must be TitleElements
-        if not all(isinstance(e, TitleElement) for e in batch_elements):
+        # All elements in batch must be TitleElements and have same level
+        if (not all(isinstance(e, TitleElement) for e in batch_elements) or
+            element.level != cast(TitleElement, batch_elements[0]).level):
             return False
 
-        # Check if all elements have the same level
-        batch_level = batch_elements[0].level
-        if element.level != batch_level:
-            return False
-
-        # Check if elements are on the same line (same parent)
         batch_parent = batch_elements[0].html_tag.parent
         element_parent = element.html_tag.parent
 
-        if batch_parent is None or element_parent is None:
+        if (batch_parent is None or element_parent is None or
+            batch_parent._bs4 != element_parent._bs4):  # noqa: SLF001
             return False
 
-        # Elements are on the same line if they have the same parent
-        if batch_parent._bs4 != element_parent._bs4:  # noqa: SLF001
-            return False
-
-        # Additional check: Don't merge sibling div elements that are separate titles
-        # This prevents merging of separate title divs that happen to be siblings
+        # Check for separate div titles that shouldn't be merged
         batch_tag = batch_elements[0].html_tag
         element_tag = element.html_tag
 
-        # Only apply this check to div elements (not span elements)
-        # Span elements are typically used for split titles that should be merged
-        # Div elements are typically used for separate titles that should not be merged
         if (batch_tag.name == "div" and element_tag.name == "div" and
             batch_parent._bs4 == element_parent._bs4):  # noqa: SLF001
 
-            # For div elements that are siblings, check if they represent separate titles
             batch_text = batch_elements[0].text.strip()
             element_text = element.text.strip()
 
-            # If both texts appear to be complete, independent titles, don't merge them
-            # This prevents cases like "Components of Results of Operations" + "Revenue"
-            # from being merged into "Components of Results of OperationsRevenue"
-            if batch_text and element_text:
-                # Check if both texts appear to be complete, independent titles
-                # For single words, we need them to be reasonably long to be considered complete titles
-                # For multi-word phrases, they are likely complete titles
-                min_single_word_length = 5
-                batch_is_substantial = len(batch_text.split()) > 1 or len(batch_text) > min_single_word_length
-                element_is_substantial = len(element_text.split()) > 1 or len(element_text) > min_single_word_length
-
-                # Additional check: if both texts are substantial AND they don't appear to be
-                # part of a split title (i.e., they don't end/start with incomplete words),
-                # then they are likely separate titles that should not be merged
-                if (batch_is_substantial and element_is_substantial and
-                    batch_text and batch_text[-1].isalpha() and
-                    element_text and element_text[0].isalpha()):
-                    return False
+            if (batch_text and element_text and
+                self._are_separate_complete_titles(batch_text, element_text)):
+                return False
 
         return True
+
+    def _are_separate_complete_titles(self, batch_text: str, element_text: str) -> bool:
+        """Check if two texts are separate complete titles that shouldn't be merged."""
+        min_single_word_length = 5
+        batch_is_substantial = len(batch_text.split()) > 1 or len(batch_text) > min_single_word_length
+        element_is_substantial = len(element_text.split()) > 1 or len(element_text) > min_single_word_length
+
+        return bool(batch_is_substantial and element_is_substantial and
+                   batch_text and batch_text[-1].isalpha() and
+                   element_text and element_text[0].isalpha())
 
     @classmethod
     def _merge(
@@ -153,29 +128,25 @@ class TitleElementMerger(AbstractElementBatchProcessingStep):
         if len(elements) == 1:
             return elements[0]
 
-        # All elements should be TitleElements
         title_elements = [cast(TitleElement, e) for e in elements]
 
-        # Create a new HTML tag that wraps all the merged elements
         new_tag = HtmlTag.wrap_tags_in_new_parent(
             "sec-parser-merged-title",
             [e.html_tag for e in title_elements],
         )
-
-        # Use the processing log from the first element
         merged_processing_log = title_elements[0].processing_log.copy()
-
-        # Add a log entry about the merging
-        merged_processing_log.add_item(
-            message=f"Merged {len(title_elements)} TitleElements: {[e.text for e in title_elements]}",
-            log_origin=cls.__name__,
-        )
-
-        # Create the merged TitleElement with the same level as the first element
+        # After merging, we retain the processing log of the first element and drop the logs of the others.
+        # This is because the merged title element now represents a single entity, and we want to avoid
+        # log duplication or confusion about which part of the merged title the logs refer to.
+        dropped_logs = [e.processing_log for e in title_elements[1:]]
+        if any(dropped_logs):
+            merged_processing_log.add_item(
+                message=f"Merged {len(title_elements)} TitleElements: {[e.text for e in title_elements]}",
+                log_origin=cls.__name__,
+            )
         return TitleElement(
             new_tag,
             processing_log=merged_processing_log,
             level=title_elements[0].level,
             log_origin=cls.__name__,
         )
-

--- a/tests/unit/processing_steps/test_title_element_merger.py
+++ b/tests/unit/processing_steps/test_title_element_merger.py
@@ -1,0 +1,174 @@
+import bs4
+import pytest
+
+from sec_parser.processing_engine.html_tag import HtmlTag
+from sec_parser.processing_steps.title_element_merger import TitleElementMerger
+from sec_parser.semantic_elements.title_element import TitleElement
+from tests.unit._utils import assert_elements
+
+
+def html_tag(tag_name: str, text: str = "Hello World") -> HtmlTag:
+    tag = bs4.Tag(name=tag_name)
+    tag.string = text
+    return HtmlTag(tag)
+
+
+def create_title_element(text: str, level: int = 0) -> TitleElement:
+    """Helper function to create a TitleElement with specific text and level."""
+    tag = html_tag("span", text)
+    return TitleElement(tag, level=level)
+
+
+def create_title_elements_with_same_parent(texts: list[str], level: int = 0) -> list[TitleElement]:
+    """Helper function to create TitleElements that share the same parent HTML element."""
+    parent_tag = bs4.Tag(name="div")
+    
+    elements = []
+    for text in texts:
+        child_tag = bs4.Tag(name="span")
+        child_tag.string = text
+        parent_tag.append(child_tag)
+        child_html_tag = HtmlTag(child_tag)
+        element = TitleElement(child_html_tag, level=level)
+        elements.append(element)
+    
+    return elements
+
+
+@pytest.mark.parametrize(
+    ("name", "elements", "expected_elements"),
+    values := [
+        (
+            "no_merge_single_title_element",
+            [
+                create_title_element("Single Title", level=0),
+            ],
+            [
+                {
+                    "type": TitleElement,
+                    "tag": "span",
+                    "text": "Single Title",
+                    "fields": {"level": 0},
+                },
+            ],
+        ),
+        (
+            "merge_adjacent_title_elements_same_level",
+            create_title_elements_with_same_parent(["PART I. FINANCI", "AL INFORMATION"], level=0),
+            [
+                {
+                    "type": TitleElement,
+                    "tag": "sec-parser-merged-title",
+                    "text": "PART I. FINANCIAL INFORMATION",
+                    "fields": {"level": 0},
+                },
+            ],
+        ),
+        (
+            "no_merge_different_levels",
+            [
+                create_title_element("Main Title", level=0),
+                create_title_element("Sub Title", level=1),
+            ],
+            [
+                {
+                    "type": TitleElement,
+                    "tag": "span",
+                    "text": "Main Title",
+                    "fields": {"level": 0},
+                },
+                {
+                    "type": TitleElement,
+                    "tag": "span",
+                    "text": "Sub Title",
+                    "fields": {"level": 1},
+                },
+            ],
+        ),
+        (
+            "merge_multiple_adjacent_title_elements",
+            create_title_elements_with_same_parent(["ITEM 1. FINANCI", "AL STATEMENTS", "AND NOTES"], level=0),
+            [
+                {
+                    "type": TitleElement,
+                    "tag": "sec-parser-merged-title",
+                    "text": "ITEM 1. FINANCIAL STATEMENTS AND NOTES",
+                    "fields": {"level": 0},
+                },
+            ],
+        ),
+        (
+            "no_merge_with_non_title_element_in_between",
+            [
+                create_title_element("First Title", level=0),
+                # This would be a different element type in practice
+                create_title_element("Second Title", level=0),
+            ],
+            [
+                {
+                    "type": TitleElement,
+                    "tag": "span",
+                    "text": "First Title",
+                    "fields": {"level": 0},
+                },
+                {
+                    "type": TitleElement,
+                    "tag": "span",
+                    "text": "Second Title",
+                    "fields": {"level": 0},
+                },
+            ],
+        ),
+    ],
+    ids=[v[0] for v in values],
+)
+def test_merge_title_elements(name, elements, expected_elements):
+    # Arrange
+    step = TitleElementMerger()
+
+    # Act
+    processed_elements = step.process(elements)
+
+    # Assert
+    assert_elements(processed_elements, expected_elements)
+
+
+def test_merge_preserves_processing_log():
+    """Test that merging preserves processing logs from the first element."""
+    elements = create_title_elements_with_same_parent(["PART I. FINANCI", "AL INFORMATION"], level=0)
+    element1, element2 = elements
+    
+    element1.processing_log.add_item(message="Test message 1", log_origin="TestOrigin")
+    element2.processing_log.add_item(message="Test message 2", log_origin="TestOrigin")
+    
+    step = TitleElementMerger()
+
+    processed_elements = step.process(elements)
+
+    assert len(processed_elements) == 1
+    merged_element = processed_elements[0]
+    assert isinstance(merged_element, TitleElement)
+    assert merged_element.text == "PART I. FINANCIAL INFORMATION"
+    assert merged_element.level == 0
+    
+    log_items = merged_element.processing_log.get_items()
+    assert len(log_items) >= 2
+    assert any("Test message 1" in str(item) for item in log_items)
+    assert any("Merged 2 TitleElements" in str(item) for item in log_items)
+
+
+def test_merge_empty_list():
+    """Test that merging an empty list raises an error."""
+    step = TitleElementMerger()
+    
+    with pytest.raises(ValueError, match="Cannot merge empty list of elements"):
+        step._merge([])
+
+
+def test_merge_single_element():
+    """Test that merging a single element returns it unchanged."""
+    element = create_title_element("Single Title", level=0)
+    step = TitleElementMerger()
+    
+    result = step._merge([element])
+    assert result is element


### PR DESCRIPTION
Fixes https://github.com/alphanome-ai/sec-parser/issues/63

Added a new TitleElementMerger processing step that identifies and merges adjacent TitleElement instances that:
- Are on the same line - Have the same parent HTML element
- Have the same level - Maintain hierarchical consistency
- Are adjacent - Appear consecutively in the element list
- Should be merged - Avoid merging separate complete titles, edge case

Tests pass, but it affects the accuracy for the MSFT 10-Q in `task snapshot-verify`
<img width="646" height="140" alt="Screenshot 2025-10-30 at 1 31 36 AM" src="https://github.com/user-attachments/assets/9be99d5e-65bc-41ac-98aa-b3b4ad7083d7" />
